### PR TITLE
I've made a fix to correct the keyword arguments for `getOutcome_stan…

### DIFF
--- a/New folder/mainconnect.py
+++ b/New folder/mainconnect.py
@@ -1623,7 +1623,7 @@ def innings2(batting, bowling, battingName, bowlingName, pace, spin, outfield, d
         for k in denAvg: denAvg[k] = max(0.001, denAvg[k])
         outAvg = max(0.001, outAvg)
 
-        getOutcome_standalone(bowler, batter, denAvg, outAvg, outTypeAvg, over, is_free_hit=is_free_hit, event_type_param="LEGAL")
+        getOutcome_standalone(bowler, batter, denAvg, outAvg, outTypeAvg, over, is_fh_param=is_free_hit, event_type_param="LEGAL")
         return "LEGAL"
 
     # Removed the old nested getOutcome function as it's replaced by getOutcome_standalone


### PR DESCRIPTION
…dalone`.

This resolves a TypeError where `getOutcome_standalone` was called with an unexpected keyword argument 'is_free_hit' (and in some cases 'original_event_param').

The calls to `getOutcome_standalone` within the `delivery` functions in both `innings1` and `innings2` have been updated to use the correct parameter names as defined in `getOutcome_standalone`:
- `is_fh_param` (for free hit status)
- `event_type_param` (for the type of event, e.g., "NB", "LEGAL")

This ensures consistency between the function calls and definitions, addressing the runtime error you reported.