### PR TITLE
Fix: Correct SyntaxError in doipl.py

### DIFF
--- a/New folder/doipl.py
+++ b/New folder/doipl.py
@@ -451,10 +451,10 @@ for team1, team2 in scheduled_matches_final:
         # Pause after match to keep console open
         input("Press Enter to continue to the next match...")
 
-        except Exception as e:
-            print(f"Error during match {team1.upper()} vs {team2.upper()}: {str(e)}")
-            input("Press Enter to continue or Ctrl+C to exit...")
-            continue
+    except Exception as e:
+        print(f"Error during match {team1.upper()} vs {team2.upper()}: {str(e)}")
+        input("Press Enter to continue or Ctrl+C to exit...")
+        continue
 
 # POINTS TABLE (Final)
 display_points_table()


### PR DESCRIPTION
The 'except Exception as e:' block within the main league matches loop was incorrectly indented, leading to a SyntaxError.

This commit fixes the indentation of the 'except' block, ensuring it is correctly aligned with its corresponding 'try' block. This resolves the SyntaxError and ensures that exceptions during match simulations are handled as intended.