### PR TITLE
Fix: Corrects "How Out" status on scorecard for free hit events

### DIFF
--- a/New folder/mainconnect.py
+++ b/New folder/mainconnect.py
@@ -634,6 +634,7 @@ def innings1(batting, bowling, battingName, bowlingName, pace, spin, outfield, d
                             is_dismissal = False
                             print(current_over_str, f"{current_bowler['displayName']} to {current_batter['player']['displayName']}", f"NOT OUT ({out_type_actual} on Free Hit!)", "Score: " + str(runs) + "/" + str(wickets))
                             ball_log_str = f"{current_over_str}:0-{out_type_actual}-FH-NotOut"
+                            batterTracker[btn]['ballLog'].append(ball_log_str) # <-- ADDED LINE
                             # Log non-dismissal event for free hit
                             innings1Log.append({"event": current_over_str + f" {current_bowler['displayName']} to {current_batter['player']['displayName']}" + f" DOT BALL ({out_type_actual} on Free Hit - Not Out!)" + " Score: " + str(runs) + "/" + str(wickets), # Added ! for emphasis
                                                 "balls": balls, "runs_this_ball": 0, "total_runs": runs, "wickets": wickets,
@@ -1526,6 +1527,7 @@ def innings2(batting, bowling, battingName, bowlingName, pace, spin, outfield, d
                             is_dismissal = False
                             print(current_over_str, f"{current_bowler['displayName']} to {current_batter['player']['displayName']}", f"NOT OUT ({out_type_actual} on Free Hit!)", "Score: " + str(runs) + "/" + str(wickets))
                             ball_log_str = f"{current_over_str}:0-{out_type_actual}-FH-NotOut"
+                            batterTracker[btn]['ballLog'].append(ball_log_str) # <-- ADDED LINE
                             innings2Log.append({"event": current_over_str + f" {current_bowler['displayName']} to {current_batter['player']['displayName']}" + f" DOT BALL ({out_type_actual} on Free Hit - Not Out!)" + " Score: " + str(runs) + "/" + str(wickets), # Added ! for emphasis
                                                 "balls": balls, "runs_this_ball": 0, "total_runs": runs, "wickets": wickets,
                                                 "batterTracker": copy.deepcopy(batterTracker), "bowlerTracker": copy.deepcopy(bowlerTracker),


### PR DESCRIPTION
Addresses a bug in `New folder/mainconnect.py` where players could be incorrectly shown as "DNB" (Did Not Bat) or have an inaccurate "Not out" status if their primary involvement in an innings was a dismissal-type event on a free hit (e.g., caught on a free hit, but ruled not out).

The issue was that the batter's personal `ballLog` (in `batterTracker`) was not being appended to for these specific "not out on free hit" scenarios. An empty `ballLog` would then lead the scorecard generation logic to incorrectly determine the player's status.

This commit fixes the issue by ensuring that `batterTracker[btn]['ballLog']` is updated with the relevant event string in both `innings1` and `innings2`'s `getOutcome_standalone` function when such a free hit non-dismissal occurs. This ensures the player is recognized as having batted, leading to a correct "Not out" status on the scorecard.