### PR TITLE
Fix: Ensure 'how_out_string' is in batterTracker for doipl.py scorecard

### DIFF
--- a/New folder/mainconnect.py
+++ b/New folder/mainconnect.py
@@ -1148,7 +1148,7 @@ def innings1(batting, bowling, battingName, bowlingName, pace, spin, outfield, d
                 if player_considered_in:
                     dismissal_status = "Not out"
                 # Else, remains "DNB" if not in this range and didn't bat.
-
+        player_specific_data['how_out_string'] = dismissal_status # <-- ADDED LINE
         batsmanTabulate.append([btckd_player_initials, runs_scored, balls_faced, sr_val, dismissal_status])
         
     bowlerTabulate = []
@@ -2426,7 +2426,7 @@ def innings2(batting, bowling, battingName, bowlingName, pace, spin, outfield, d
                 if player_considered_in:
                     dismissal_status = "Not out"
                 # Else, remains "DNB" if not in this range and didn't bat.
-
+        player_specific_data['how_out_string'] = dismissal_status # <-- ADDED LINE
         batsmanTabulate.append([btckd_player_initials, runs_scored, balls_faced, sr_val, dismissal_status])
         
     bowlerTabulate = []


### PR DESCRIPTION
This addresses a bug where the scorecard displayed by `doipl.py` would incorrectly show "DNB" (Did Not Bat) for most players.

The root cause was that `mainconnect.py`, while calculating the dismissal status for its internal logging, did not store this status string in the `batterTracker` dictionary under the key 'how_out_string'. The `doipl.py` script's `display_scorecard` function relies on this 'how_out_string' field and would default to "DNB" when it was missing.

I've modified the `innings1()` and `innings2()` functions in `New folder/mainconnect.py`. In the scorecard generation section at the end of each innings, after the `dismissal_status` for a player is determined, it is now also stored in that player's dictionary within `batterTracker` using the key 'how_out_string'.

This ensures that the `innings1Battracker` and `innings2Battracker` (returned by the `game()` function) provide the necessary data structure for `doipl.py` to correctly display how each player was out, or their not-out/DNB status.