### PR TITLE
Fix: Correct Super Over bowler selection and log display order

### DIFF
--- a/New folder/doipl.py
+++ b/New folder/doipl.py
@@ -377,12 +377,12 @@ for team1, team2 in scheduled_matches_final:
                 resList[bowl_tracker_key]
             )
 
-        print(f"\nResult: {resList['winMsg']}")
         if resList.get('superOverPlayed', False) and resList.get('superOverDetails'):
             print("--- Super Over Details ---")
             for detail in resList['superOverDetails']:
                 print(detail)
             print("-------------------------")
+        print(f"\nResult: {resList['winMsg']}")
         print(random.choice(commentary_lines['end']))
 
         # Track batting/bowling format win
@@ -497,12 +497,12 @@ def playoffs(team1, team2, matchtag):
                 res[bowl_tracker_key]
             )
         
-        print(f"\nResult: {res['winMsg'].upper()}")
         if res.get('superOverPlayed', False) and res.get('superOverDetails'):
             print("--- Super Over Details ---")
             for detail in res['superOverDetails']:
                 print(detail)
             print("-------------------------")
+        print(f"\nResult: {res['winMsg'].upper()}")
         print(random.choice(commentary_lines['end']))
 
         winner = res['winner']


### PR DESCRIPTION
This commit addresses two issues related to the Super Over feature:

1.  **Incorrect Bowler Selection for Super Over:**
    *   Refined the bowler selection logic within `simulate_super_over_innings()` in `mainconnect.py`.
    *   Added more robust checks when iterating through the bowling team's player list and accessing their main match bowling stats from the tracker.
    *   This includes verifying player initials, ensuring tracker entries are dictionaries, and confirming that `balls_bowled > 0` in the main match.
    *   These changes make the identification of eligible bowlers for the Super Over more resilient, preventing the "No bowler from team X bowled..." error when bowlers did participate.

2.  **Super Over Log Display Order:**
    *   Modified `doipl.py` in both the main league match loop and the `playoffs()` function.
    *   The printing of Super Over details (from `superOverDetails` list) is now done *before* printing the final match result string (`winMsg`).
    *   This ensures a more chronological and user-friendly presentation of events when a Super Over occurs.