### PR TITLE
Fix: Ensure rain_expected flag is passed to game simulation

### DIFF
--- a/New folder/doipl.py
+++ b/New folder/doipl.py
@@ -377,7 +377,7 @@ for team1, team2 in scheduled_matches_final:
         input("Press Enter to start the match...")
         print(random.choice(commentary_lines['start']))
 
-        resList = game(False, team1, team2)
+        resList = game(False, team1, team2, switch="group", rain_expected=rain_expected_for_this_match)
 
         # Display ball-by-ball and innings summary for both innings
         for innings, team_key, runs_key, balls_key, bat_tracker_key, bowl_tracker_key in [
@@ -544,7 +544,7 @@ def playoffs(team1, team2, matchtag):
         input("Press Enter to start the playoff match...")
         print(random.choice(commentary_lines['start']))
         
-        res = game(False, team1.lower(), team2.lower(), matchtag)
+        res = game(False, team1.lower(), team2.lower(), switch=matchtag, rain_expected=False)
         
         for innings, team_key, runs_key, balls_key, bat_tracker_key, bowl_tracker_key in [
             ('innings1Log', 'innings1BatTeam', 'innings1Runs', 'innings1Balls', 'innings1Battracker', 'innings1Bowltracker'),


### PR DESCRIPTION
Addresses an issue where no matches were experiencing rain delays despite logic being in place to select 1-3 matches for potential rain. The `rain_expected_for_this_match` boolean flag determined in `doipl.py` was not being passed to the `mainconnect.game()` function.

This commit makes the following changes to `New folder/doipl.py`:
1.  In the main league matches loop, the call to `mainconnect.game()` now includes the `rain_expected=rain_expected_for_this_match` argument.
2.  In the `playoffs()` function, the call to `mainconnect.game()` now explicitly includes `rain_expected=False`, as the current rain selection targets only league matches.

These changes ensure that the `game()` function in `mainconnect.py` receives the correct `rain_expected` status, enabling the pre-match rain delay and over reduction logic to trigger for the appropriately selected league matches.