### PR TITLE
Fix: Correct game() signature to accept rain_expected argument

### DIFF
--- a/New folder/mainconnect.py
+++ b/New folder/mainconnect.py
@@ -2449,7 +2449,7 @@ def innings2(batting, bowling, battingName, bowlingName, pace, spin, outfield, d
     innings2Battracker = batterTracker
     innings2Bowltracker = bowlerTracker
 
-def game(manual=True, sentTeamOne=None, sentTeamTwo=None, switch="group"):
+def game(manual=True, sentTeamOne=None, sentTeamTwo=None, switch="group", rain_expected=False):
     global innings1Batting, innings1Bowling, innings2Batting, innings2Bowling, innings1Balls, innings2Balls
     global innings1Log, innings2Log, innings1Battracker, innings2Battracker, innings2Bowltracker, innings1Bowltracker
     global innings1Runs, innings2Runs


### PR DESCRIPTION
Addresses a TypeError: `game() got an unexpected keyword argument 'rain_expected'`. This occurred because `doipl.py` was modified to pass the `rain_expected` flag to `mainconnect.game()`, but the signature of `mainconnect.game()` had not been updated to include this new parameter.

This commit modifies the function definition of `game()` in `New folder/mainconnect.py` to: `def game(manual=True, sentTeamOne=None, sentTeamTwo=None, switch="group", rain_expected=False):`

This ensures the function signature is compatible with the calls from `doipl.py`, allowing the `rain_expected` flag to be correctly passed and processed for simulating rain delays.